### PR TITLE
Use template for rotl, fix shift by 0 places

### DIFF
--- a/src/siphash.d
+++ b/src/siphash.d
@@ -238,9 +238,10 @@ enum SipRound = "
 ";
 
 @safe pure nothrow
-ulong rotl(in ulong u, in uint s)
+T rotl(T)(in T u, in uint s)
+    if (__traits(isArithmetic, T) && __traits(isUnsigned, T))
 {
-    return (u << s) | (u >> (64 - s));
+    return (u << s) | (u >> (-s & (T.sizeof * 8 - 1)));
 }
 
 @trusted pure nothrow


### PR DESCRIPTION
With this template, data types other than 64-bit ulongs can be bit-rotated, provided they are 1) unsigned, 2) arithmetic. This eliminates the assumption that all ulongs are 64-bits in size, and allows the function to potentially be used more generally.

More importantly, this also fixes [(potentially?) undefined behaviour when a rotate is performed by 0 places](https://en.wikipedia.org/wiki/Bitwise_operation#Rotate_through_carry).

With GDC the code still compiles down to one instruction on x86-64.

In practice, this PR likely does not make a difference in all currently existing uses of the rotl function, but might avoid complications in the future and is a nice little snippet.
