### PR TITLE
Remove deprecated "clear()"

### DIFF
--- a/src/siphash.d
+++ b/src/siphash.d
@@ -151,7 +151,7 @@ struct SipHash(size_t C, size_t D)
             v2 = k0 ^ 0x6c7967656e657261UL;
             v3 = k1 ^ 0x7465646279746573UL;
             processedLength = 0;
-            message.clear();
+            message = message.init;
         }
 
         /**


### PR DESCRIPTION
`clear()` has been [deprecated](http://dlang.org/deprecate.html#clear) in 2.066 and removed in 2.068.

I'm not quite sure if the replacement code I wrote is quite correct. Maybe using the new allocators for memory management would be better.

This fixes compilation on dmd >= v2.068. (Tested in dmd v2.069)
